### PR TITLE
Fix rollup export warning

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -9,6 +9,7 @@ export default {
   output: {
     file: 'dist/plugin.js',
     format: 'iife',
+    exports: 'named',
     name: 'windyPluginHeatUnits',
     globals: {
       leaflet: 'L'


### PR DESCRIPTION
## Summary
- configure Rollup to use `exports: 'named'`

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68873008130c832189bee70614551712