### PR TITLE
Update plugin domain references

### DIFF
--- a/.github/workflows/publish-plugin.yml
+++ b/.github/workflows/publish-plugin.yml
@@ -30,6 +30,6 @@ jobs:
       - name: Publish to Windy
         if: github.ref == 'refs/heads/main'
         run: |
-          curl -XPOST 'https://node.windy.com/plugins/v1.0/upload' \
+          curl -XPOST 'https://www.windy-plugins.com/plugins/v1.0/upload' \
             -H "x-windy-api-key: ${{ secrets.WINDY_API_KEY }}" \
             -F "plugin_archive=@./plugin.tar"

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 This plugin calculates and visualizes Growing Degree Days (GDD) for agricultural planning and crop management. It integrates seamlessly with Windy.com's weather platform to provide farmers and agricultural professionals with essential heat unit data.
 
+Once published, you can load the plugin directly from [https://www.windy-plugins.com/plugins/heat-units](https://www.windy-plugins.com/plugins/heat-units).
+
 ## Features
 
 - **Real-time GDD calculation** for any location on the map
@@ -30,7 +32,7 @@ This plugin calculates and visualizes Growing Degree Days (GDD) for agricultural
    ```bash
    npm start
    ```
-4. Open Windy.com and navigate to `https://www.windy.com/dev` to test the plugin
+4. Open Windy Plugins and navigate to `https://www.windy-plugins.com/dev` to test the plugin
 
 ### Production Deployment
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "windy-plugin-heat-units",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "windy-plugin-heat-units",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-commonjs": "^25.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "windy-plugin-heat-units",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Agricultural Heat Unit (Growing Degree Days) calculator and visualization plugin for Windy.com",
   "main": "dist/plugin.js",
   "scripts": {

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "windy-plugin-heat-units",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "title": "Agricultural Heat Units",
   "description": "Calculate and visualize Growing Degree Days (GDD) for optimal crop management and agricultural planning",
   "author": "crop-crusaders",

--- a/src/pluginConfig.ts
+++ b/src/pluginConfig.ts
@@ -2,7 +2,7 @@ import type { ExternalPluginConfig } from './windyInterfaces';
 
 const config: ExternalPluginConfig = {
   name: 'windy-plugin-heat-units',
-  version: '1.0.0',
+  version: '1.0.1',
   icon: '🌡️',
   title: 'Agricultural Heat Units',
   description: 'Calculate and visualize Growing Degree Days (GDD) for optimal crop management and agricultural planning',


### PR DESCRIPTION
## Summary
- update README with new windy-plugins.com URL
- update GitHub Actions to publish to windy-plugins.com

## Testing
- ❌ `npm ci --silent` (POST to registry.npmjs.org blocked)
- ❌ `npm run build` (rollup not found)


------
https://chatgpt.com/codex/tasks/task_e_6887329f13cc8321ad16e38ceb2614fd