### PR TITLE
Clarify README about dev server

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,14 @@ Once published, you can load the plugin directly from [https://www.windy-plugins
    ```bash
    npm install
    ```
-3. Start development server:
+3. Start the build watcher:
    ```bash
    npm start
    ```
-4. Open Windy Plugins and navigate to `https://www.windy-plugins.com/dev` to test the plugin
+4. Open Windy Plugins and navigate to `https://www.windy-plugins.com/dev` to test the plugin.
+   The official getting-started guide mentions a local server at
+   `https://localhost:9999/plugin.js`, but this project only compiles the
+   plugin; it does not start a web server.
 
 ### Production Deployment
 


### PR DESCRIPTION
## Summary
- clarify that running `npm start` only builds the plugin
- mention the outdated docs reference to a localhost server

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688739d343fc832186ca415d0e83d262