### PR TITLE
Update publish workflow to use release script

### DIFF
--- a/.github/workflows/publish-plugin.yml
+++ b/.github/workflows/publish-plugin.yml
@@ -29,7 +29,6 @@ jobs:
 
       - name: Publish to Windy
         if: github.ref == 'refs/heads/main'
-        run: |
-          curl --fail -XPOST 'https://www.windy-plugins.com/plugins/v1.0/upload' \
-            -H "x-windy-api-key: ${{ secrets.WINDY_API_KEY }}" \
-            -F "plugin_archive=@./windy-plugin-heat-units.tar"
+        env:
+          WINDY_API_KEY: ${{ secrets.WINDY_API_KEY }}
+        run: npm run release

--- a/README.md
+++ b/README.md
@@ -51,8 +51,12 @@ work consistently with the GitHub Actions workflow.
    a secure HTTPS connection.
 4. To publish manually from your local machine, run:
    ```bash
+   export WINDY_API_KEY=<your_key>
    npm run release
    ```
+   The `npm run release` script invokes `curl` with the `x-windy-api-key` header
+   and uploads `windy-plugin-heat-units.tar`. If the API key is missing or
+   invalid, the upload request will fail with `403 Forbidden`.
 
 ## Usage
 


### PR DESCRIPTION
## Summary
- call `npm run release` from GitHub Actions

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68875bd64b348321a85abe80f3823b10