### PR TITLE
Enable debug logging in publish workflow

### DIFF
--- a/.github/workflows/publish-plugin.yml
+++ b/.github/workflows/publish-plugin.yml
@@ -65,7 +65,7 @@ jobs:
           # Upload with better error handling
           echo "Uploading plugin to Windy..."
           set -x
-          response=$(curl -v -L -w "%{http_code}" -s -o response.json --fail-with-body \
+          response=$(curl -v -L -w "%{http_code}" -o response.json --fail-with-body \
             -XPOST 'https://windy-plugins.com/plugins/v1.0/upload' \
             -H "x-windy-api-key: $WINDY_API_KEY" \
             -F 'plugin_archive=@./windy-plugin-heat-units.tar')


### PR DESCRIPTION
## Summary
- add `ACTIONS_RUNNER_DEBUG` and `ACTIONS_STEP_DEBUG` to build job
- enable verbose curl output and command tracing during plugin upload

## Testing
- `npm test`
- `npm run lint` *(fails: 9 errors)*
- `npm run type-check` *(fails: 11 errors)*
- `gh issue create` *(fails: authentication required)*

------
https://chatgpt.com/codex/tasks/task_e_688814abe0f48321abc3143e0af078c2