### PR TITLE
Fix plugin build for ESM

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -8,12 +8,7 @@ export default {
   input: 'src/plugin.ts',
   output: {
     file: 'dist/plugin.js',
-    format: 'iife',
-    exports: 'named',
-    name: 'windyPluginHeatUnits',
-    globals: {
-      leaflet: 'L'
-    },
+    format: 'es',
     inlineDynamicImports: true
   },
   plugins: [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "module": "ESNext",
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,


### PR DESCRIPTION
## Summary
- output ES module instead of IIFE so Windy can import the plugin
- add `verbatimModuleSyntax` to tsconfig

## Testing
- `npm run lint` *(fails: Parsing error: '>' expected)*
- `npm run type-check` *(fails to compile TypeScript)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68886594744c83218f7c46d512899afa