### PR TITLE
Bump plugin version to 1.0.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "windy-plugin-heat-units",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "windy-plugin-heat-units",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-commonjs": "^26.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "windy-plugin-heat-units",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Agricultural Heat Unit (Growing Degree Days) calculator and visualization plugin for Windy.com",
   "main": "dist/plugin.js",
   "homepage": "https://github.com/crop-crusaders/windy-plugin-heat-units#readme",

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "windy-plugin-heat-units",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "title": "Agricultural Heat Units",
   "description": "Calculate and visualize Growing Degree Days (GDD) for optimal crop management and agricultural planning",
   "author": "crop-crusaders",

--- a/src/pluginConfig.ts
+++ b/src/pluginConfig.ts
@@ -2,7 +2,7 @@ import type { ExternalPluginConfig } from './windyInterfaces';
 
 const config: ExternalPluginConfig = {
   name: 'windy-plugin-heat-units',
-  version: '1.0.3',
+  version: '1.0.4',
   icon: '🌡️',
   title: 'Agricultural Heat Units',
   description: 'Calculate and visualize Growing Degree Days (GDD) for optimal crop management and agricultural planning',


### PR DESCRIPTION
## Summary
- bump the plugin version metadata to 1.0.4 in plugin.json and the build configuration
- update package manifests to reflect the new 1.0.4 release version

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68e5a7dece288321a461cb5dc9f8a754