### PR TITLE
chore: bump plugin version to 1.0.5

### DIFF
--- a/dist/plugin.js
+++ b/dist/plugin.js
@@ -1,6 +1,6 @@
 const config = {
     name: 'windy-plugin-heat-units',
-    version: '1.0.4',
+    version: '1.0.5',
     icon: '🌡️',
     title: 'Agricultural Heat Units',
     description: 'Calculate and visualize Growing Degree Days (GDD) for optimal crop management and agricultural planning',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "windy-plugin-heat-units",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "windy-plugin-heat-units",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-commonjs": "^26.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "windy-plugin-heat-units",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Agricultural Heat Unit (Growing Degree Days) calculator and visualization plugin for Windy.com",
   "main": "dist/plugin.js",
   "homepage": "https://github.com/crop-crusaders/windy-plugin-heat-units#readme",

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "windy-plugin-heat-units",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "title": "Agricultural Heat Units",
   "description": "Calculate and visualize Growing Degree Days (GDD) for optimal crop management and agricultural planning",
   "author": "crop-crusaders",

--- a/src/pluginConfig.ts
+++ b/src/pluginConfig.ts
@@ -2,7 +2,7 @@ import type { ExternalPluginConfig } from './windyInterfaces';
 
 const config: ExternalPluginConfig = {
   name: 'windy-plugin-heat-units',
-  version: '1.0.4',
+  version: '1.0.5',
   icon: '🌡️',
   title: 'Agricultural Heat Units',
   description: 'Calculate and visualize Growing Degree Days (GDD) for optimal crop management and agricultural planning',


### PR DESCRIPTION
## Summary
- bump the plugin metadata to version 1.0.5 in package, manifest, and runtime config
- rebuild the compiled bundle so the published artifact reports version 1.0.5

## Testing
- npm run build:prod

------
https://chatgpt.com/codex/tasks/task_e_68e5be936e7483218aafb44adce9df5e