### PR TITLE
Handle missing Windy host element when mounting plugin

### DIFF
--- a/dist/plugin.js
+++ b/dist/plugin.js
@@ -18,20 +18,77 @@ const config = {
 /**
  * Main plugin entry point that integrates with Windy.com
  */
-const plugin$1 = async (params, utils) => {
+const plugin$1 = async (params) => {
     const { el } = params;
+    const target = ensureHostElement(params, el);
+    target.innerHTML = '';
+    target.dataset.pluginReady = 'true';
     // Import the Svelte component
     const Plugin = (await Promise.resolve().then(function () { return plugin; })).default;
-    // Initialize the plugin component
-    const pluginInstance = new Plugin({
-        target: el,
-        props: {},
-    });
+    let pluginInstance = null;
+    try {
+        // Initialize the plugin component
+        pluginInstance = new Plugin({
+            target,
+            props: {},
+        });
+    }
+    catch (error) {
+        console.error('Failed to mount Windy heat units plugin UI:', error);
+        renderBootstrapError(target);
+        return () => {
+            target.removeAttribute('data-plugin-ready');
+        };
+    }
     // Return cleanup function
     return () => {
-        pluginInstance.$destroy();
+        if (pluginInstance) {
+            pluginInstance.$destroy();
+            pluginInstance = null;
+        }
+        if (!el && target.parentElement) {
+            target.parentElement.removeChild(target);
+        }
     };
 };
+function ensureHostElement(params, existing) {
+    if (existing instanceof HTMLElement) {
+        return existing;
+    }
+    const fallbackContainer = document.createElement('section');
+    fallbackContainer.className = 'windy-plugin-heat-units-root';
+    fallbackContainer.style.minHeight = '220px';
+    fallbackContainer.style.padding = '16px';
+    fallbackContainer.style.background = 'rgba(255, 255, 255, 0.95)';
+    fallbackContainer.style.color = '#2c3e50';
+    const parent = getParentHost(params);
+    parent.appendChild(fallbackContainer);
+    return fallbackContainer;
+}
+function getParentHost(params) {
+    const potentialParent = 'node' in params && params.node instanceof HTMLElement
+        ? params.node
+        : 'root' in params && params.root instanceof HTMLElement
+            ? params.root
+            : null;
+    return potentialParent ?? document.body;
+}
+function renderBootstrapError(target) {
+    const errorContainer = document.createElement('div');
+    errorContainer.className = 'windy-plugin-heat-units-error';
+    errorContainer.style.padding = '16px';
+    errorContainer.style.background = 'rgba(231, 76, 60, 0.12)';
+    errorContainer.style.border = '1px solid rgba(231, 76, 60, 0.35)';
+    errorContainer.style.borderRadius = '8px';
+    errorContainer.style.color = '#c0392b';
+    errorContainer.innerHTML = `
+    <h3 style="margin: 0 0 8px 0; font-size: 1rem;">Plugin failed to load</h3>
+    <p style="margin: 0; font-size: 0.85rem; line-height: 1.4;">
+      The Agricultural Heat Units interface could not be initialised. Please reload the plugin or check the browser console for details.
+    </p>
+  `;
+    target.appendChild(errorContainer);
+}
 
 /** @returns {void} */
 function noop() {}

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -4,23 +4,93 @@ import config from './pluginConfig';
 /**
  * Main plugin entry point that integrates with Windy.com
  */
-const plugin: PluginDataLoader = async (params, utils) => {
+const plugin: PluginDataLoader = async (params) => {
   const { el } = params;
+
+  const target = ensureHostElement(params, el);
+
+  target.innerHTML = '';
+  target.dataset.pluginReady = 'true';
 
   // Import the Svelte component
   const Plugin = (await import('./plugin.svelte')).default;
 
-  // Initialize the plugin component
-  const pluginInstance = new Plugin({
-    target: el,
-    props: {},
-  });
+  let pluginInstance: InstanceType<typeof Plugin> | null = null;
+
+  try {
+    // Initialize the plugin component
+    pluginInstance = new Plugin({
+      target,
+      props: {},
+    });
+  } catch (error) {
+    console.error('Failed to mount Windy heat units plugin UI:', error);
+    renderBootstrapError(target);
+
+    return () => {
+      target.removeAttribute('data-plugin-ready');
+    };
+  }
 
   // Return cleanup function
   return () => {
-    pluginInstance.$destroy();
+    if (pluginInstance) {
+      pluginInstance.$destroy();
+      pluginInstance = null;
+    }
+
+    if (!el && target.parentElement) {
+      target.parentElement.removeChild(target);
+    }
   };
 };
+
+function ensureHostElement(params: Record<string, unknown>, existing: HTMLElement | undefined) {
+  if (existing instanceof HTMLElement) {
+    return existing;
+  }
+
+  const fallbackContainer = document.createElement('section');
+  fallbackContainer.className = 'windy-plugin-heat-units-root';
+  fallbackContainer.style.minHeight = '220px';
+  fallbackContainer.style.padding = '16px';
+  fallbackContainer.style.background = 'rgba(255, 255, 255, 0.95)';
+  fallbackContainer.style.color = '#2c3e50';
+
+  const parent = getParentHost(params);
+  parent.appendChild(fallbackContainer);
+
+  return fallbackContainer;
+}
+
+function getParentHost(params: Record<string, unknown>) {
+  const potentialParent =
+    'node' in params && params.node instanceof HTMLElement
+      ? params.node
+      : 'root' in params && params.root instanceof HTMLElement
+        ? params.root
+        : null;
+
+  return potentialParent ?? document.body;
+}
+
+function renderBootstrapError(target: HTMLElement) {
+  const errorContainer = document.createElement('div');
+  errorContainer.className = 'windy-plugin-heat-units-error';
+  errorContainer.style.padding = '16px';
+  errorContainer.style.background = 'rgba(231, 76, 60, 0.12)';
+  errorContainer.style.border = '1px solid rgba(231, 76, 60, 0.35)';
+  errorContainer.style.borderRadius = '8px';
+  errorContainer.style.color = '#c0392b';
+  errorContainer.innerHTML = `
+    <h3 style="margin: 0 0 8px 0; font-size: 1rem;">Plugin failed to load</h3>
+    <p style="margin: 0; font-size: 0.85rem; line-height: 1.4;">
+      The Agricultural Heat Units interface could not be initialised. Please reload the plugin or check the browser console for details.
+    </p>
+  `;
+
+  target.appendChild(errorContainer);
+}
 
 // Export the plugin
 export default plugin;


### PR DESCRIPTION
## Summary
- ensure the plugin always has a host element by creating a fallback container when Windy does not supply one
- add defensive cleanup and a bootstrap error message when the Svelte component fails to mount

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e5c04a6ff88321a6244febb6f0e4d9