### PR TITLE
Add script to verify WINDY_API_KEY before release

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,10 +48,12 @@ work consistently with the GitHub Actions workflow.
 
 1. Get API key from https://api.windy.com/keys
 2. Add `WINDY_API_KEY` to your GitHub repository secrets
-3. Push to the `main` branch. The GitHub Actions workflow automatically builds
+3. (Optional) Run `npm run check:api-key` locally to confirm the environment
+   variable is available before triggering a release.
+4. Push to the `main` branch. The GitHub Actions workflow automatically builds
    the plugin, packages it as `windy-plugin-heat-units.tar`, and uploads it over
    a secure HTTPS connection.
-4. To publish manually from your local machine, run:
+5. To publish manually from your local machine, run:
    ```bash
    export WINDY_API_KEY=<your_key>
    npm run release

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "package": "npm run clean && npm run build:prod && tar cf windy-plugin-heat-units.tar --exclude='windy-plugin-heat-units.tar' --exclude='.git' --exclude='node_modules' --exclude='src' --exclude='*.config.*' --exclude='tsconfig.json' .",
     "prerelease": "npm run lint && npm run type-check",
     "release": "bash -c 'set -e; if [ -z \"$WINDY_API_KEY\" ]; then echo \"❌ Error: WINDY_API_KEY is not set\" && exit 1; fi; echo \"🔍 Running pre-release checks...\"; npm run prerelease; echo \"🔨 Building plugin...\"; npm run build:prod; echo \"📦 Creating package...\"; npm run package; echo \"📊 Package size: $(stat -c%s windy-plugin-heat-units.tar 2>/dev/null || stat -f%z windy-plugin-heat-units.tar) bytes\"; echo \"📤 Uploading to Windy...\"; response=$(curl -L -w \"%{http_code}\" -s -o /tmp/windy_response.json --fail-with-body -XPOST https://node.windy.com/plugins/v1.0/upload -H \"x-windy-api-key: $WINDY_API_KEY\" -F \"plugin_archive=@./windy-plugin-heat-units.tar\"); http_code=\"${response: -3}\"; echo \"📊 HTTP Status: $http_code\"; if [ -f /tmp/windy_response.json ]; then echo \"📋 Response:\"; cat /tmp/windy_response.json; echo; fi; if [ \"$http_code\" = \"404\" ] || [ \"$http_code\" = \"410\" ]; then echo \"Endpoint not found (HTTP $http_code). Check docs.\"; exit 1; fi; if [ \"$http_code\" -ge 200 ] && [ \"$http_code\" -lt 300 ]; then echo \"✅ Plugin uploaded successfully!\"; rm -f /tmp/windy_response.json; else echo \"❌ Upload failed with HTTP $http_code\"; exit 1; fi'",
-    "dev": "npm run start"
+    "dev": "npm run start",
+    "check:api-key": "node scripts/check-api-key.mjs"
   },
   "keywords": [
     "windy",

--- a/scripts/check-api-key.mjs
+++ b/scripts/check-api-key.mjs
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+/**
+ * Simple utility to verify that the WINDY_API_KEY environment variable
+ * is configured before running release automation.
+ */
+const apiKey = process.env.WINDY_API_KEY?.trim();
+
+if (!apiKey) {
+  console.error("❌ WINDY_API_KEY is not set.\n\n" +
+    "Set the environment variable before invoking release commands.\n" +
+    "For example:\n" +
+    "  export WINDY_API_KEY=your_api_key_here\n" +
+    "  npm run release");
+  process.exit(1);
+}
+
+if (/^\*+$/.test(apiKey)) {
+  console.warn("⚠️  The WINDY_API_KEY appears to be masked (only asterisks).\n" +
+    "Double-check that your secret manager or shell exported the real value before releasing.");
+}
+
+console.log("✅ WINDY_API_KEY is configured. Ready to run release workflows.");


### PR DESCRIPTION
## Summary
- add a small Node.js utility that validates the WINDY_API_KEY environment variable
- expose the helper through an npm script and document the optional pre-release check

## Testing
- WINDY_API_KEY=abc123 npm run check:api-key

------
https://chatgpt.com/codex/tasks/task_e_68e5c7c775448321a88ed06e29cff936