### PR TITLE
chore: bump plugin version to 1.0.7

### DIFF
--- a/dist/plugin.js
+++ b/dist/plugin.js
@@ -1,6 +1,6 @@
 const config = {
     name: 'windy-plugin-heat-units',
-    version: '1.0.6',
+    version: '1.0.7',
     icon: '🌡️',
     title: 'Agricultural Heat Units',
     description: 'Calculate and visualize Growing Degree Days (GDD) for optimal crop management and agricultural planning',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "windy-plugin-heat-units",
-  "version": "1.0.5",
+  "version": "1.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "windy-plugin-heat-units",
-      "version": "1.0.5",
+      "version": "1.0.7",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-commonjs": "^26.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "windy-plugin-heat-units",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Agricultural Heat Unit (Growing Degree Days) calculator and visualization plugin for Windy.com",
   "main": "dist/plugin.js",
   "homepage": "https://github.com/crop-crusaders/windy-plugin-heat-units#readme",

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "windy-plugin-heat-units",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "title": "Agricultural Heat Units",
   "description": "Calculate and visualize Growing Degree Days (GDD) for optimal crop management and agricultural planning",
   "author": "crop-crusaders",

--- a/src/pluginConfig.ts
+++ b/src/pluginConfig.ts
@@ -2,7 +2,7 @@ import type { ExternalPluginConfig } from './windyInterfaces';
 
 const config: ExternalPluginConfig = {
   name: 'windy-plugin-heat-units',
-  version: '1.0.6',
+  version: '1.0.7',
   icon: '🌡️',
   title: 'Agricultural Heat Units',
   description: 'Calculate and visualize Growing Degree Days (GDD) for optimal crop management and agricultural planning',


### PR DESCRIPTION
## Summary
- bump the plugin metadata version to 1.0.7 for the next release
- regenerate the distribution bundle so it reports the updated version

## Testing
- npm run build:prod

------
https://chatgpt.com/codex/tasks/task_e_68e5c9a136588321ab13375a51dd2163