### PR TITLE
Bump plugin version to 1.0.10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "windy-plugin-heat-units",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "windy-plugin-heat-units",
-      "version": "1.0.9",
+      "version": "1.0.10",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-commonjs": "^26.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "windy-plugin-heat-units",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "Agricultural Heat Unit (Growing Degree Days) calculator and visualization plugin for Windy.com",
   "main": "dist/plugin.js",
   "homepage": "https://github.com/crop-crusaders/windy-plugin-heat-units#readme",

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "windy-plugin-heat-units",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "title": "Agricultural Heat Units",
   "description": "Calculate and visualize Growing Degree Days (GDD) for optimal crop management and agricultural planning",
   "author": "crop-crusaders",


### PR DESCRIPTION
## Summary
- bump the package and plugin manifest versions to 1.0.10 to allow a new upload

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e5d9e896e8832181c0d282c6c9c541