### PR TITLE
Add troubleshooting guidance for dev certificate errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,15 @@ work consistently with the GitHub Actions workflow.
    `http://localhost:9999/plugin.js`, but this project only compiles the
    plugin; it does not start a web server.
 
+### Troubleshooting development builds
+
+- **"Error loading plugin... dev server is not running"**: Windy loads
+  development builds over HTTPS with a self-signed certificate. Open the
+  requested URL (for example,
+  `https://windy-plugins.com/11047871/windy-plugin-heat-units/1.0.11/plugin.min.js`)
+  directly in your browser and accept the certificate warning. Reload the
+  Windy Plugin dev page afterwards and the bundle will be served correctly.
+
 ### Production Deployment
 
 1. Get API key from https://api.windy.com/keys


### PR DESCRIPTION
## Summary
- document how to resolve the Windy dev server self-signed certificate warning in the README

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5e1fbef248321a2d690d4b752f8c7