### PR TITLE
Add plugin URL verification script for release troubleshooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@
 This plugin calculates and visualizes Growing Degree Days (GDD) for agricultural planning and crop management. It integrates seamlessly with Windy.com's weather platform to provide farmers and agricultural professionals with essential heat unit data.
 
 Once published, you can load the plugin directly from `https://windy-plugins.com/plugins/windy-plugin-heat-units/plugin.json`.
-If that URL returns a `NoSuchKey` error, the upload may not have completed or it hasn't propagated yet.
+If that URL returns a `NoSuchKey` error, run `npm run check:plugin-url` to verify whether the file is reachable. The script performs
+a quick HEAD request and prints guidance if the upload is still propagating or the path is incorrect.
 
 ## Features
 
@@ -56,6 +57,12 @@ work consistently with the GitHub Actions workflow.
   `https://windy-plugins.com/11047871/windy-plugin-heat-units/1.0.11/plugin.min.js`)
   directly in your browser and accept the certificate warning. Reload the
   Windy Plugin dev page afterwards and the bundle will be served correctly.
+- **"NoSuchKey" while loading the production URL**: Confirm that the GitHub
+  Actions release workflow completed successfully. Then run `npm run
+  check:plugin-url` locally to ensure the published file is live. If the
+  command reports `NoSuchKey`, wait a few minutes and retry—the CDN may still
+  be propagating the asset. Persistent `NoSuchKey` responses indicate the
+  release did not finish and the archive must be uploaded again.
 
 ### Frequently asked questions
 
@@ -85,6 +92,14 @@ troubleshooting section and reload the page.
    The `npm run release` script invokes `curl` with the `x-windy-api-key` header
    and uploads `windy-plugin-heat-units.tar`. If the API key is missing or
    invalid, the upload request will fail with `403 Forbidden`.
+
+6. After the upload completes, verify that the CDN is serving the new build:
+   ```bash
+   npm run check:plugin-url
+   ```
+   The command checks the published `plugin.json` and reports whether the file
+   is accessible. If the response still mentions `NoSuchKey`, wait a few
+   minutes for propagation or rerun the release if the asset never appears.
    
    **Note:** Some networks block POST requests to `windy-plugins.com`. If the
    upload fails with `Method forbidden`, run the release from a network that

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "prerelease": "npm run lint && npm run type-check",
     "release": "bash -c 'set -e; if [ -z \"$WINDY_API_KEY\" ]; then echo \"❌ Error: WINDY_API_KEY is not set\" && exit 1; fi; echo \"🔍 Running pre-release checks...\"; npm run prerelease; echo \"🔨 Building plugin...\"; npm run build:prod; echo \"📦 Creating package...\"; npm run package; echo \"📊 Package size: $(stat -c%s windy-plugin-heat-units.tar 2>/dev/null || stat -f%z windy-plugin-heat-units.tar) bytes\"; echo \"📤 Uploading to Windy...\"; response=$(curl -L -w \"%{http_code}\" -s -o /tmp/windy_response.json --fail-with-body -XPOST https://node.windy.com/plugins/v1.0/upload -H \"x-windy-api-key: $WINDY_API_KEY\" -F \"plugin_archive=@./windy-plugin-heat-units.tar\"); http_code=\"${response: -3}\"; echo \"📊 HTTP Status: $http_code\"; if [ -f /tmp/windy_response.json ]; then echo \"📋 Response:\"; cat /tmp/windy_response.json; echo; fi; if [ \"$http_code\" = \"404\" ] || [ \"$http_code\" = \"410\" ]; then echo \"Endpoint not found (HTTP $http_code). Check docs.\"; exit 1; fi; if [ \"$http_code\" -ge 200 ] && [ \"$http_code\" -lt 300 ]; then echo \"✅ Plugin uploaded successfully!\"; rm -f /tmp/windy_response.json; else echo \"❌ Upload failed with HTTP $http_code\"; exit 1; fi'",
     "dev": "npm run start",
-    "check:api-key": "node scripts/check-api-key.mjs"
+    "check:api-key": "node scripts/check-api-key.mjs",
+    "check:plugin-url": "node scripts/check-plugin-url.mjs"
   },
   "keywords": [
     "windy",

--- a/scripts/check-plugin-url.mjs
+++ b/scripts/check-plugin-url.mjs
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+import { exit } from 'node:process';
+
+const DEFAULT_URL = 'https://windy-plugins.com/plugins/windy-plugin-heat-units/plugin.json';
+const url = process.argv[2] ?? DEFAULT_URL;
+
+async function fetchWithTimeout(method) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 5000);
+  try {
+    const response = await fetch(url, { method, signal: controller.signal });
+    clearTimeout(timeout);
+    return response;
+  } catch (error) {
+    clearTimeout(timeout);
+    throw error;
+  }
+}
+
+async function main() {
+  let lastNetworkError;
+
+  for (const method of ['HEAD', 'GET']) {
+    try {
+      const response = await fetchWithTimeout(method);
+      if (response.ok) {
+        console.log(`✅ ${url} is reachable (HTTP ${response.status}) via ${method}.`);
+        exit(0);
+      }
+
+      let bodySnippet = '';
+      try {
+        const text = await response.text();
+        bodySnippet = text.slice(0, 200);
+      } catch (readError) {
+        bodySnippet = `<unable to read body: ${readError.message ?? readError}>`;
+      }
+
+      console.error(`❌ Received HTTP ${response.status} ${response.statusText} when requesting ${url} with ${method}.`);
+      if (bodySnippet.includes('NoSuchKey')) {
+        console.error('The server reports "NoSuchKey"—the upload has not propagated or the path is incorrect.');
+      } else if (bodySnippet) {
+        console.error(`Response preview: ${bodySnippet}`);
+      }
+
+      if (method === 'HEAD' && response.status === 405) {
+        console.error('The server rejected HEAD requests; retrying with GET...');
+        continue;
+      }
+
+      exit(1);
+    } catch (error) {
+      lastNetworkError = error;
+      if (error.name === 'AbortError') {
+        console.error(`❌ Timed out after 5s while trying to reach ${url} with ${method}.`);
+      } else {
+        const message = error.message ?? String(error);
+        console.error(`❌ Network error while requesting ${url} with ${method}: ${message}`);
+      }
+
+      if (method === 'HEAD') {
+        console.error('Retrying with GET to gather more details...');
+        continue;
+      }
+
+      console.error('Double-check your internet connection and ensure the plugin was released.');
+      exit(1);
+    }
+  }
+
+  if (lastNetworkError) {
+    console.error('Unable to reach the plugin URL after multiple attempts.');
+    console.error('Double-check your internet connection and ensure the plugin was released.');
+  }
+  exit(1);
+}
+
+main();


### PR DESCRIPTION
## Summary
- add a CLI helper that verifies the published plugin URL and surfaces NoSuchKey responses
- expose the checker through a new npm script and document how to use it after releases

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e5e79de3a08321a8b9e21d3042c8d4